### PR TITLE
Update web socket port to be unique from ZEC and HUSH

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -125,9 +125,9 @@ MainWindow::MainWindow(QWidget *parent) :
 }
  
 void MainWindow::createWebsocket(QString wormholecode) {
-    qDebug() << "Listening for app connections on port 8237";
+    qDebug() << "Listening for app connections on port 8877";
     // Create the websocket server, for listening to direct connections
-    wsserver = new WSServer(8237, false, this);
+    wsserver = new WSServer(8877, false, this);
 
     if (!wormholecode.isEmpty()) {
         // Connect to the wormhole service

--- a/src/websockets.cpp
+++ b/src/websockets.cpp
@@ -320,7 +320,7 @@ void AppDataServer::updateUIWithNewQRCode(MainWindow* mainwindow) {
     if (ipv4Addr.isEmpty())
         return;
     
-    QString uri = "ws://" + ipv4Addr + ":8237";
+    QString uri = "ws://" + ipv4Addr + ":8877";
 
     // Get a new secret
     unsigned char* secretBin = new unsigned char[crypto_secretbox_KEYBYTES];


### PR DESCRIPTION
This allows `zecwallet`, `silentdragon` and `sevenseas` to all co-exist on the same machine with their respective android apps connected correctly.